### PR TITLE
chore: refactors dialog to be more performant and flexible

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+# EditorConfig is awesome: https://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+indent_style = space
+indent_size = 2

--- a/apps/ui-generator/src/modules/store/components/ConfigLoader.svelte
+++ b/apps/ui-generator/src/modules/store/components/ConfigLoader.svelte
@@ -30,12 +30,12 @@
     <div class="cluster | actions">
 
         <button
-            class="nc-button import-button" data-dialogtarget="import-dialog"
+            class="nc-button import-button" dialogtarget="import-dialog"
         >
             Import
         </button>
         <button
-            class="nc-button export-button" data-dialogtarget="export-dialog"
+            class="nc-button export-button" dialogtarget="export-dialog"
         >
             Export
         </button>

--- a/apps/ui-generator/src/modules/store/components/ConfigLoader.svelte
+++ b/apps/ui-generator/src/modules/store/components/ConfigLoader.svelte
@@ -29,8 +29,16 @@
 <div style={allStyles} class="stack container">
     <div class="cluster | actions">
 
-        <button class="nc-button import-button" data-opens-dialog="import-dialog">Import</button>
-        <button class="nc-button export-button" data-opens-dialog="export-dialog">Export</button>
+        <button
+            class="nc-button import-button" data-dialogtarget="import-dialog"
+        >
+            Import
+        </button>
+        <button
+            class="nc-button export-button" data-dialogtarget="export-dialog"
+        >
+            Export
+        </button>
         <button class="nc-button" on:click={togglePreview}>Preview</button>
     </div>
     <ExportDialog allStyles={allStyles}/>

--- a/apps/ui-generator/src/modules/store/components/ExportDialog.svelte
+++ b/apps/ui-generator/src/modules/store/components/ExportDialog.svelte
@@ -1,8 +1,6 @@
 <script>
     import {configStore} from "../configStore";
-
     export let allStyles = '';
-
 
     const copyStyleExport = async () => {
         const exportString = configStore.exportToString()
@@ -17,11 +15,12 @@
     }
 </script>
 
-<dialog class="nc-dialog" data-id="export-dialog" data-level="1" style="max-inline-size: 50rem">
+<dialog class="nc-dialog" id="export-dialog" data-level="1" style="max-inline-size: 50rem">
     <div class="dialog-container">
         <div class="dialog-header">
             <h2 class="dialog-title">Export Theme</h2>
-            <button data-closes-dialog="export-dialog">X</button>
+            <!-- svelte-ignore a11y-autofocus -->
+            <button autofocus data-closes-dialog="export-dialog">X</button>
         </div>
         <div class="dialog-content">
             <pre>
@@ -35,7 +34,7 @@
                     data-has-notification
                     data-notification-title="✓ To clipboard"
                     data-notification-description="Copied all styles to clipboard"
-                    data-closes-dialog="export-dialog"
+                    data-closes-dialog
             >Copy to clipboard
             </button>
             <button on:click={copyStyleExport}

--- a/apps/ui-generator/src/modules/store/components/ExportDialog.svelte
+++ b/apps/ui-generator/src/modules/store/components/ExportDialog.svelte
@@ -17,7 +17,7 @@
     }
 </script>
 
-<dialog data-id="export-dialog" data-level="1" style="max-inline-size: 50rem">
+<dialog class="nc-dialog" data-id="export-dialog" data-level="1" style="max-inline-size: 50rem">
     <div class="dialog-container">
         <div class="dialog-header">
             <h2 class="dialog-title">Export Theme</h2>

--- a/apps/ui-generator/src/modules/store/components/ImportDialog.svelte
+++ b/apps/ui-generator/src/modules/store/components/ImportDialog.svelte
@@ -10,11 +10,12 @@
 
 </script>
 
-<dialog class="nc-dialog" data-id="import-dialog" data-level="1" style="max-inline-size: 50rem">
+<dialog class="nc-dialog" id="import-dialog" data-level="1" style="max-inline-size: 50rem">
     <div class="dialog-container">
         <div class="dialog-header">
             <h2 class="dialog-title">Import Theme</h2>
-            <button data-closes-dialog="import-dialog">X</button>
+            <!-- svelte-ignore a11y-autofocus -->
+            <button autofocus data-closes-dialog>X</button>
         </div>
         <div class="dialog-content">
             <div class="stack">

--- a/apps/ui-generator/src/modules/store/components/ImportDialog.svelte
+++ b/apps/ui-generator/src/modules/store/components/ImportDialog.svelte
@@ -10,7 +10,7 @@
 
 </script>
 
-<dialog data-id="import-dialog" data-level="1" style="max-inline-size: 50rem">
+<dialog class="nc-dialog" data-id="import-dialog" data-level="1" style="max-inline-size: 50rem">
     <div class="dialog-container">
         <div class="dialog-header">
             <h2 class="dialog-title">Import Theme</h2>

--- a/packages/ui/src/modules/dialogs/svelte/dialog.svelte
+++ b/packages/ui/src/modules/dialogs/svelte/dialog.svelte
@@ -1,23 +1,23 @@
 <script lang="ts">
   export let heading: string = '';
+  export const id: string = '';
 </script>
 
 
 <dialog
   class="nc-dialog"
-  data-id="dialog-1"
+  {id}
   data-level="1"
   inert
-  loading
 >
-  <div class="dialog-container">
+  <form method="dialog" class="dialog-container">
     <div class="dialog-header">
       <h2 class="dialog-title">{heading}</h2>
-      <button data-closes-dialog="dialog-1">X</button>
+      <button data-closes-dialog>X</button>
     </div>
     <div class="dialog-content">
       <slot />
       <button data-opens-dialog="dialog-2">Show me the next dialog</button>
     </div>
-  </div>
+  </form>
 </dialog>

--- a/packages/ui/src/modules/dialogs/svelte/dialog.svelte
+++ b/packages/ui/src/modules/dialogs/svelte/dialog.svelte
@@ -1,16 +1,23 @@
 <script lang="ts">
-
+  export let heading: string = '';
 </script>
 
 
-<dialog data-id="dialog-1" data-level="1">
-      <div class="dialog-container">
-        <div class="dialog-header">
-          <h2 class="dialog-title">I'm a dialog (1)</h2>
-          <button data-closes-dialog="dialog-1">X</button>
-        </div>
-        <div class="dialog-content">
-          <button data-opens-dialog="dialog-2">Show me the next dialog</button>
-        </div>
-      </div>
-    </dialog>
+<dialog
+  class="nc-dialog"
+  data-id="dialog-1"
+  data-level="1"
+  inert
+  loading
+>
+  <div class="dialog-container">
+    <div class="dialog-header">
+      <h2 class="dialog-title">{heading}</h2>
+      <button data-closes-dialog="dialog-1">X</button>
+    </div>
+    <div class="dialog-content">
+      <slot />
+      <button data-opens-dialog="dialog-2">Show me the next dialog</button>
+    </div>
+  </div>
+</dialog>

--- a/packages/ui/src/modules/dialogs/ts/LICENCE
+++ b/packages/ui/src/modules/dialogs/ts/LICENCE
@@ -1,0 +1,171 @@
+Copyright 2023 Adam Argyle
+
+Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+   1. Definitions.
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+   END OF TERMS AND CONDITIONS
+   APPENDIX: How to apply the Apache License to your work.
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+   Copyright [yyyy] [name of copyright owner]
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+       http://www.apache.org/licenses/LICENSE-2.0
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/ui/src/modules/dialogs/ts/dialogs.ts
+++ b/packages/ui/src/modules/dialogs/ts/dialogs.ts
@@ -1,52 +1,113 @@
-const openButtons = document.querySelectorAll<HTMLButtonElement>(
-  "button[data-opens-dialog]"
-);
-const closeButtons = document.querySelectorAll<HTMLButtonElement>(
-  "button[data-closes-dialog]"
-);
-const openDialogs: HTMLDialogElement[] = [];
+// custom events to be added to <dialog>
+const dialogClosingEvent = new Event('closing')
+const dialogClosedEvent  = new Event('closed')
+const dialogOpeningEvent = new Event('opening')
+const dialogOpenedEvent  = new Event('opened')
+const dialogRemovedEvent = new Event('removed')
 
-openButtons.forEach((button) => {
-  button.addEventListener("click", () => {
-    const dialog = document.querySelector<HTMLDialogElement>(
-      `[data-id="${button.dataset.opensDialog}"]`
-    );
-    dialog.showModal();
-    openDialogs.forEach((d, idx) => {
-      d.style.setProperty(
-        "--dialog-inative-offset",
-        `${-1 * (openDialogs.length + 1 - idx)}dvh`
-      );
-      d.classList.add("-inactive");
-    });
-    openDialogs.push(dialog);
-  });
+// track opening
+const dialogAttrObserver = new MutationObserver((mutations, observer) => {
+  mutations.forEach(async mutation => {
+    if (mutation.attributeName === 'open') {
+      const dialog = mutation.target as HTMLDialogElement;
+
+      const isOpen = dialog.hasAttribute('open')
+      if (!isOpen) return
+
+      dialog.removeAttribute('inert')
+
+      // set focus
+      const focusTarget = dialog.querySelector('[autofocus]') as HTMLDialogElement;
+      focusTarget
+        ? focusTarget?.focus()
+        : dialog?.querySelector('button')?.focus()
+
+      dialog.dispatchEvent(dialogOpeningEvent)
+      await animationsComplete(dialog)
+      dialog.dispatchEvent(dialogOpenedEvent)
+    }
+  })
+})
+
+// track deletion
+const dialogDeleteObserver = new MutationObserver((mutations, observer) => {
+  mutations.forEach(mutation => {
+    mutation.removedNodes.forEach(removedNode => {
+      if (removedNode.nodeName === 'DIALOG') {
+        removedNode.removeEventListener('click', lightDismiss)
+        removedNode.removeEventListener('close', dialogClose)
+        removedNode.dispatchEvent(dialogRemovedEvent)
+      }
+    })
+  })
+})
+
+// wait for all dialog animations to complete their promises
+const animationsComplete = (element: HTMLDialogElement) =>
+  Promise.allSettled(
+    element.getAnimations().map((animation: Animation) => 
+      animation.finished))
+
+// click outside the dialog handler
+const lightDismiss = ({ target: dialog }) => {
+  console.log(dialog.nodeName);
+  
+  if (dialog.nodeName === 'DIALOG')
+    dialog.close('dismiss')
+}
+
+const dialogClose = async ({target:dialog}) => {
+  dialog.setAttribute('inert', '')
+  dialog.dispatchEvent(dialogClosingEvent)
+
+  await animationsComplete(dialog)
+
+  dialog.dispatchEvent(dialogClosedEvent)
+}
+
+// page load dialogs setup
+export async function initDialog(dialog: HTMLDialogElement) {
+  dialog.addEventListener('click', lightDismiss)
+  dialog.addEventListener('close', dialogClose)
+
+  dialogAttrObserver.observe(dialog, { 
+    attributes: true,
+  })
+
+  dialogDeleteObserver.observe(document.body, {
+    attributes: false,
+    subtree: false,
+    childList: true,
+  })
+
+  // remove visibility:hidden style
+  // prevent page load @keyframes playing
+  await animationsComplete(dialog);
+  // dialog.style.removeProperty('visibility');
+}
+
+const dialogRemoved = ({ target: dialog }) => {
+  dialog.removeEventListener('removed', dialogRemoved)
+}
+
+// SETUP
+document.querySelectorAll('dialog').forEach((dialog: HTMLDialogElement) => {
+  // sugar up <dialog> elements
+  initDialog(dialog);
+
+  dialog.addEventListener('removed', dialogRemoved)
 });
 
-closeButtons.forEach((button) => {
-  button.addEventListener("click", () => {
-    closeCurrentDialog();
-  });
-});
+const htmlEl = document.querySelector('html');
+htmlEl?.addEventListener('click', (e: MouseEvent) => {
+  const el = e.target as HTMLElement;
 
-const closeCurrentDialog = () => {
-  const currentDialog = openDialogs.pop();
-  if (!currentDialog) {
-    return;
+  if (el.hasAttribute('data-dialogtarget')) {
+    const dialogId = el.getAttribute('data-dialogtarget');
+    if (dialogId) window[dialogId].showModal();
   }
 
-  currentDialog.addEventListener(
-    "animationend",
-    () => {
-      currentDialog.classList.remove("-closing");
-      currentDialog.close();
-      if (openDialogs.length === 0) {
-        return;
-      }
-      openDialogs[openDialogs.length - 1].classList.remove("-inactive");
-    },
-    { once: true }
-  );
-
-  currentDialog.classList.add("-closing");
-};
+  if (el.hasAttribute('data-closes-dialog')) {
+    (el as HTMLButtonElement)?.closest('dialog')?.close('close');
+  }
+});

--- a/packages/ui/src/modules/dialogs/ts/dialogs.ts
+++ b/packages/ui/src/modules/dialogs/ts/dialogs.ts
@@ -93,7 +93,7 @@ document.querySelectorAll('dialog').forEach((dialog: HTMLDialogElement) => {
   // sugar up <dialog> elements
   initDialog(dialog);
 
-  dialog.addEventListener('removed', dialogRemoved)
+  dialog.addEventListener('removed', dialogRemoved, { once: true });
 });
 
 const htmlEl = document.documentElement;

--- a/packages/ui/src/modules/dialogs/ts/dialogs.ts
+++ b/packages/ui/src/modules/dialogs/ts/dialogs.ts
@@ -102,8 +102,8 @@ const htmlEl = document.querySelector('html');
 htmlEl?.addEventListener('click', (e: MouseEvent) => {
   const el = e.target as HTMLElement;
 
-  if (el.hasAttribute('data-dialogtarget')) {
-    const dialogId = el.getAttribute('data-dialogtarget');
+  if (el.hasAttribute('dialogtarget')) {
+    const dialogId = el.getAttribute('dialogtarget');
     if (dialogId) window[dialogId].showModal();
   }
 

--- a/packages/ui/src/modules/dialogs/ts/dialogs.ts
+++ b/packages/ui/src/modules/dialogs/ts/dialogs.ts
@@ -50,8 +50,6 @@ const animationsComplete = (element: HTMLDialogElement) =>
 
 // click outside the dialog handler
 const lightDismiss = ({ target: dialog }) => {
-  console.log(dialog.nodeName);
-  
   if (dialog.nodeName === 'DIALOG')
     dialog.close('dismiss')
 }

--- a/packages/ui/src/modules/dialogs/ts/dialogs.ts
+++ b/packages/ui/src/modules/dialogs/ts/dialogs.ts
@@ -96,7 +96,7 @@ document.querySelectorAll('dialog').forEach((dialog: HTMLDialogElement) => {
   dialog.addEventListener('removed', dialogRemoved)
 });
 
-const htmlEl = document.querySelector('html');
+const htmlEl = document.documentElement;
 htmlEl?.addEventListener('click', (e: MouseEvent) => {
   const el = e.target as HTMLElement;
 

--- a/packages/ui/src/styles/components/dialogs.css
+++ b/packages/ui/src/styles/components/dialogs.css
@@ -23,14 +23,6 @@
             background: rgba(0, 0, 0, 0.05);
             backdrop-filter: blur(2px);
         }
-
-        &[open]:not([inert]):nth-of-type(2) {
-            transform: translate(0, calc(var(--spacing-base) * 1)) scale(0.98);
-        }
-
-        &[open]:not([inert]):nth-of-type(3) {
-            transform: translate(0, calc(var(--spacing-base) * 1)) scale(0.97);
-        }
     }
 
     .nc-dialog {

--- a/packages/ui/src/styles/components/dialogs.css
+++ b/packages/ui/src/styles/components/dialogs.css
@@ -1,5 +1,25 @@
 @layer components {
     dialog {
+        position: fixed;
+        inset: 0;
+        z-index: var(--layer-important);
+        animation: close-dialog var(--transition-duration-base) cubic-bezier(0.7, 0, 1, 1) forwards;
+
+        &[open] {
+            animation: open-dialog var(--transition-duration-base) cubic-bezier(0, 0.6, 0.58, 1);
+        }
+
+        &:not([open]) {
+            pointer-events: none;
+            opacity: 0;
+        }
+
+        &[loading] {
+            visibility: hidden;
+        }
+    }
+
+    .nc-dialog {
         --_dialog-radius: var(--dialog-radius, var(--border-radius-medium));
         --_dialog-padding-inline: var(--dialog-padding-inline, var(--spacing-base));
         --_dialog-close-size: var(--dialog-close-size, var(--button-height-base));
@@ -12,20 +32,19 @@
         max-inline-size: 28rem;
         background: var(--color-surface-strong);
         box-shadow: var(--shadow-medium);
-        margin: 5dvh auto;
+        margin-block: 5dvh;
+        margin-inline: auto;
         padding: 0;
         border-radius: var(--_dialog-radius);
-        animation: open-dialog var(--transition-duration-base) cubic-bezier(0, 0.6, 0.58, 1);
-        position: fixed;
         transition: transform var(--transition-duration-base) cubic-bezier(0, 0.6, 0.58, 1);
     }
 
     .dialog-container {
         display: grid;
         grid-template:
-      'header header' calc(2 * var(--spacing-near) + var(--_dialog-close-size))
-      'content content' 1fr
-      'footer footer' auto / 1fr 1fr;
+          'header header' calc(2 * var(--spacing-near) + var(--_dialog-close-size))
+          'content content' 1fr
+          'footer footer' auto / 1fr 1fr;
         inline-size: 100%;
         block-size: 100%;
     }

--- a/packages/ui/src/styles/components/dialogs.css
+++ b/packages/ui/src/styles/components/dialogs.css
@@ -1,12 +1,17 @@
 @layer components {
     dialog {
+        --_dialog-transition-duration: var(--dialog-transition-duration, var(--transition-duration-base));
+
+        display: block;
         position: fixed;
         inset: 0;
         z-index: var(--layer-important);
-        animation: close-dialog var(--transition-duration-base) cubic-bezier(0.7, 0, 1, 1) forwards;
+        animation: close-dialog var(--_dialog-transition-duration) cubic-bezier(0.7, 0, 1, 1) forwards;
+        transition: opacity var(--_dialog-transition-duration) cubic-bezier(0.7, 0, 1, 1);
+        overflow: hidden;
 
         &[open] {
-            animation: open-dialog var(--transition-duration-base) cubic-bezier(0, 0.6, 0.58, 1);
+            animation: open-dialog var(--_dialog-transition-duration) cubic-bezier(0, 0.6, 0.58, 1);
         }
 
         &:not([open]) {
@@ -14,8 +19,17 @@
             opacity: 0;
         }
 
-        &[loading] {
-            visibility: hidden;
+        &::backdrop {
+            background: rgba(0, 0, 0, 0.05);
+            backdrop-filter: blur(2px);
+        }
+
+        &[open]:not([inert]):nth-of-type(2) {
+            transform: translate(0, calc(var(--spacing-base) * 1)) scale(0.98);
+        }
+
+        &[open]:not([inert]):nth-of-type(3) {
+            transform: translate(0, calc(var(--spacing-base) * 1)) scale(0.97);
         }
     }
 
@@ -23,8 +37,6 @@
         --_dialog-radius: var(--dialog-radius, var(--border-radius-medium));
         --_dialog-padding-inline: var(--dialog-padding-inline, var(--spacing-base));
         --_dialog-close-size: var(--dialog-close-size, var(--button-height-base));
-
-        --dialog-inative-offset: 0;
 
         border: var(--border-width-thin) solid var(--color-border-base);
         inline-size: calc(100dvw - 2 * var(--spacing-base));
@@ -36,7 +48,6 @@
         margin-inline: auto;
         padding: 0;
         border-radius: var(--_dialog-radius);
-        transition: transform var(--transition-duration-base) cubic-bezier(0, 0.6, 0.58, 1);
     }
 
     .dialog-container {
@@ -94,21 +105,6 @@
 
     html:has(dialog[open]) {
         overflow: hidden;
-        max-inline-size: 100%;
-        max-block-size: 100%;
-    }
-
-    dialog::backdrop {
-        background: rgba(0, 0, 0, 0.05);
-        backdrop-filter: blur(2px);
-    }
-
-    dialog.-closing {
-        animation: close-dialog var(--transition-duration-base) cubic-bezier(0.7, 0, 1, 1) forwards;
-    }
-
-    dialog.-inactive {
-        transform: translate(0, var(--dialog-inative-offset)) scale(0.98);
     }
 
     @keyframes open-dialog {


### PR DESCRIPTION
* It makes more use of event delegation to reduce the amount of event listeners
* It separates styling between `dialog` and `.nc-dialog` to give the ability for users to use the base styling for a dialog along with it's functionality and add more detailed styling by adding a `class="nc-dialog"` sticking with the naming convention for other css components (e.g. `nc-card`)
* It mimics the Popover API by using `dialogtarget`.
* It removes the necessity to give `data-closes-dialog` a dialog ID value by targeting it's closest `dialog` element.
* Sets `autofocus` attribute for [better a11y](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dialog?retiredLocale=de#accessibility_considerations).
* Removes necessity for extra class `-closing`.
* Yet, did not migrate `inactive` stacking feature… 